### PR TITLE
Update GH Actions ubuntu runner in main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   release:
     name: GitHub Active Users
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
         with:


### PR DESCRIPTION
This is updates the runner image to avoid eventual breakage as GitHub is decommissioning the ubuntu-20.04 image this spring (more at the link below).

https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/